### PR TITLE
Correct 16-bit float decoding for compressed keyframes

### DIFF
--- a/io_scene_rw_anm/anm.py
+++ b/io_scene_rw_anm/anm.py
@@ -8,8 +8,18 @@ ANM_ACTION_VERSION = 0x100
 ANM_ACTION_PARENT_NONE_OFFSET = 0xFF30C9D8
 
 
+def decode_float16(value):
+    sign = -1.0 if (value >> 15) else 1.0
+    if (value & 0x7FFF) == 0:
+        return sign * 0.0
+    exponent = ((value >> 11) & 15) - 15
+    mantissa = (value & 0x07FF) / 0x800 + 1.0
+    return sign * mantissa * 2**exponent
+
+
 def read_float16(fd, num=1, en='<'):
-    res = struct.unpack('%s%de' % (en, num), fd.read(2 * num))
+    res = struct.unpack('%s%dH' % (en, num), fd.read(2 * num))
+    res = tuple(map(decode_float16, res))
     return res if num > 1 else res[0]
 
 


### PR DESCRIPTION
This pull request fixes the importing of animations that use the compressed keyframes scheme.

Previously, the plugin was reading 16-bit floats as IEEE 754 half floats, which they can't be (they were added to the standard in 2008, but I have games from 2003 using compressed keyframes).

I checked the code of the [Max plugin](https://github.com/Shadowth117/Renderware-.anm-IO-Tool) for how the 16-bit floats are decoded, and they do look like floating-point numbers, but they have 4 bits of exponent instead of IEEE's 5 (not to mention that the [Renderware User Guide](https://github.com/electronicarts/RenderWare3Docs/blob/master/userguide/UserGuideVol2.pdf) claims they are fixed-point, which turns out to be a lie). And the range of exponents possible is only between [-15, 0], so the 16-bit float used by Renderware was designed to mainly cover numbers in the [-1.0,1.0] range.

In this pull request, I fixed this issue by reading the 16-bit float numbers as unsigned integers, then pass it to the new `decode_float16` function that decodes it to a "Pythonic" float. I tried to make it work similarly to the Max plugin, the difference being that instead of shifting bits to a IEEE 32-bit float representation then bitcasting it, I simply read the sign, mantissa and exponent separately and do the math, like how one you would do in class when learning floating-point numbers. I tested with several compressed animations and it now works. My method might not be the fastest, but I don't see any other way. And I believe there shouldn't be any precision problem.

Btw, great work on your plugin! :+1: I have tried it with animations from the games of the Asterix XXL series, and all animations that use uncompressed keyframes work flawlessly. And the export works well too, which gives our modding community more possibilities in terms of animation. I hope this pull request can also benefit other games using Renderware that might also use compressed keyframes.